### PR TITLE
Fix null pointer exception

### DIFF
--- a/src/Configurator/OptionsMenu/pages/FieldsPreviewPage/index.tsx
+++ b/src/Configurator/OptionsMenu/pages/FieldsPreviewPage/index.tsx
@@ -27,9 +27,8 @@ interface State {
 }
 
 class FieldsPreviewPage extends React.Component<Props, State> {
-	private readonly pageName = `${this.props.name.slice(0, 1).toUpperCase()}${this.props.name.slice(
-		1
-	)}`;
+	private readonly pageName =
+		this.props.name && `${this.props.name.slice(0, 1).toUpperCase()}${this.props.name.slice(1)}`;
 
 	constructor(props: Props) {
 		super(props);

--- a/src/Configurator/OptionsMenu/pages/PanelsPage/index.tsx
+++ b/src/Configurator/OptionsMenu/pages/PanelsPage/index.tsx
@@ -157,7 +157,7 @@ export default function PanelsPage(props: Props) {
 					<ShareIcon className="icon" width="25px" height="25px" />
 				</div>
 			</PageContainer>
-			{(pageStatus && <FieldsPreviewPage onBack={closePage} name={contexualProps.name} />) || null}
+			{(pageStatus && <FieldsPreviewPage onBack={closePage} name={contexualProps?.name} />) || null}
 		</>
 	);
 }


### PR DESCRIPTION
There is a null pointer exception when users tap at any field on pass that makes the app unusable.
This PR fixes it.